### PR TITLE
Issue 1 - Sort episodes

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,7 +10,6 @@ $client = new GuzzleHttp\Client();
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
-
 //Sort the episodes
 function episode_sort($a, $b) {
   if ($a['season'] == $b['season']) {

--- a/public/index.php
+++ b/public/index.php
@@ -10,8 +10,17 @@ $client = new GuzzleHttp\Client();
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
+
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+function episode_sort($a, $b) {
+  if ($a['season'] == $b['season']) {
+    return ($a['episode'] < $b['episode']) ? -1 : 1;
+  } else {
+    return ($a['season'] < $b['season']) ? -1 : 1;
+  }
+}
+usort($data, "episode_sort");
+
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);

--- a/public/index.php
+++ b/public/index.php
@@ -20,6 +20,5 @@ function episode_sort($a, $b) {
 }
 usort($data, "episode_sort");
 
-
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
This PR adds in a more tailored sort for the data returned from the API, sorting by season and then by episode.

The sort function may need to be moved to a file with other public functions. I couldn't seem to find one suitable so have currently left it in the index.php file.

---

**Testing**

Either add in more episodes across various seasons or change current episodes to see the order change.

---

**Deployment steps**

Merge branch `issue1` into `master`

Compile assets: `./bin/node_modules/gulp`
