### PR TITLE
Change tooltip so only one appears

### DIFF
--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -12,9 +12,10 @@ module.exports = function () {
     $('body').popover({
         selector: '[data-toggle="popover"]',
         container: 'body',
+        trigger: 'focus',
         viewport: { selector: 'body', padding: 20 }
     })
-    
+
     // Initialise Bootstrap tooltips
     //http://getbootstrap.com/javascript/#tooltips
     $('[data-toggle="tooltip"]').tooltip()

--- a/templates/episode.html
+++ b/templates/episode.html
@@ -1,7 +1,7 @@
 <div class="col-sm-6 episode">
     <div class="media">
         <div class="media-left">
-            <img src="{{ episode.image }}" class="media-object" alt="{{ episode.title }}" width="200" data-toggle="popover" data-content="{{ episode.title }}">
+            <img tabindex="{{ loop.index }}" src="{{ episode.image }}" class="media-object" alt="{{ episode.title }}" width="200" data-toggle="popover" data-content="{{ episode.title }}">
         </div>
         <div class="media-body">
             <h4 class="media-heading">{{ episode.title }} <small><i>Season {{ episode.season }} Episode {{ episode.episode }}</i></small></h4>


### PR DESCRIPTION
The popover options were changed so that it triggers on focus. This requires the tabindex to be set on the image.

---

**Testing**

Load the page and click on an image to see a tooltip. Click on another one to see the previous one disappear and the new one appear.

---

**Deployment steps**

Merge branch `issue4` into `master`

Compile assets: `/node_modules/.bin/gulp`
