### PR TITLE
Issue 2 - Handle API error

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -6,12 +6,18 @@ $loader = new Twig_Loader_Filesystem('../templates/');
 $twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
+try {
+  $client = new GuzzleHttp\Client();
+  $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+  $data = json_decode($res->getBody(), true);
+  $error = '';
 
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+  //Sort the episodes
+  array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+} catch (\GuzzleHttp\Exception\RequestException $e) {
+  $data = [];
+  $error = 'Sorry, there was an error. Please try again by reloading the page.';
+}
 
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', ["episodes" => $data, "error" => $error]);

--- a/templates/page.html
+++ b/templates/page.html
@@ -15,11 +15,14 @@
     </div>
 
     <div class="container">
+        {% if error != '' %}
+            <div class="alert alert-danger">{{ error }}</div>
+        {%endif %}
         {% for episode in episodes %}
             {% if loop.index%2 == 1 %}<div class="row">{%endif %}
 
                 {{ include('episode.html') }}
-        
+
             {% if loop.index%2 == 0 %}</div>{%endif %}
         {% endfor %}
     </div>


### PR DESCRIPTION
Handle the API 500 error with a try catch. Pass on an error message to the page template and display in a bootstrap styled alert. Pass on empty array.

---

**Testing**

Keep refreshing the page to recreate the error as described in the issue. Every now and then you should see the episodes are replaced with an error notice, but the rest of the page renders. Unlike before where you would just see a PHP error.

---

**Deployment steps**

Merge branch `issue2` into `master`

Compile assets: `/node_modules/.bin/gulp`
