### PR TITLE
Issue 3 - Adjust template styling to match design image

### DIFF
--- a/public/resources/sass/components/_episode.scss
+++ b/public/resources/sass/components/_episode.scss
@@ -1,7 +1,20 @@
 .episode {
     p {
         font-family: 'PT Serif', serif;
-        font-size: 15px;
-        line-height: 25px;            
+        font-size: 13px;
+        line-height: 22px;
+    }
+
+    .media-left,
+    .media-body {
+      padding-bottom: 20px;
+    }
+
+    .media-heading {
+      font-weight: bold;
+
+      i {
+        color: #777;
+      }
     }
 }

--- a/public/resources/sass/utilities/_variables.scss
+++ b/public/resources/sass/utilities/_variables.scss
@@ -29,7 +29,7 @@ $font-size-base:          15px;
 $font-size-large:         18px;
 $font-size-small:         14px;
 
-$font-size-h1:            48px;
+$font-size-h1:            58px;
 $font-size-h2:            36px;
 $font-size-h3:            24px;
 $font-size-h4:            18px;


### PR DESCRIPTION
Adjusted the _episode.scss file to make the episodes look more like the design image. The episodes had most work, including spacing. Also adjusted the main h1 font size variable to 10px larger.

I would probably have prefered to switch this to a flex or grid layout instead so that the spacing was more fluid.

If further changes are required, an illustrator, XD or sketch file might be useful, or the original, so that I can inspect the elements and more easily check their size, font, and colour.

---

**Testing**

Refresh the page on the latest compile and the page should look more like the design.

---

**Deployment steps**

Tell us what we would need to do to get your changes into production. (We are aware that in this test, this is mostly a case of merging your branch). e.g.

Merge branch `issue3` into `master`

Compile assets: `/node_modules/bin/gulp`
