### PR TITLE
Change 1 - Added cache functionality

### DIFF
--- a/public/episodes-cache.txt
+++ b/public/episodes-cache.txt
@@ -1,0 +1,72 @@
+{
+	"s8e2": {
+		"title": "You Only Move Twice",
+		"image": "http://3ev.org/dev-test-api/images/simpsons-you-only-move-twice.jpg",
+		"synopsis": "Homer takes a new job in a new town. However, his friendly new boss might be a super villain bent on world domination.",
+		"season": 8,
+		"episode": 8
+	},
+	"s6e4": {
+		"title": "Itchy & Scratchy Land",
+		"image": "http://3ev.org/dev-test-api/images/itchy-and-scratchy-land.jpg",
+		"synopsis": "A family vacation to Itchy & Scratchy Land turns disastrous when the robots malfunction and turn on the tourists.",
+		"season": 6,
+		"episode": 6
+	},
+	"s11e22": {
+		"title": "Behind The Laughter",
+		"image": "http://3ev.org/dev-test-api/images/behind-the-laughter-simpsons.jpg",
+		"synopsis": "The Simpsons discuss their fame in a behind the scenes look at the show.",
+		"season": 11,
+		"episode": 22
+	},
+	"s8e22": {
+		"title": "Homer’s Enemy",
+		"image": "http://3ev.org/dev-test-api/images/homers-enemy.jpg",
+		"synopsis": "Industrious Frank Grimes starts working at the plant beside Homer. He complains to the other employees about how useless Homer is, which causes them to wonder why Frank is being so troublesome.",
+		"season": 8,
+		"episode": 22
+	},
+	"s4e12": {
+		"title": "Marge Vs. The Monorail",
+		"image": "http://3ev.org/dev-test-api/images/simpsons-monorail.jpg",
+		"synopsis": "After receiving a considerable donation of money, the people of Springfield decide what to spend it on. Enter Lyle Langley, a jocular salesman who gets Springfield hooked on a monorail ...",
+		"season": 4,
+		"episode": 12
+	},
+	"s6e12": {
+		"title": "Homer The Great",
+		"image": "http://3ev.org/dev-test-api/images/homer-the-great-simpsons.jpg",
+		"synopsis": "Homer becomes a member of a mysterious organization called the Stonecutters and is heralded as \"the chosen one\".",
+		"season": 6,
+		"episode": 12
+	},
+	"s4e3": {
+		"title": "Homer The Heretic",
+		"image": "http://3ev.org/dev-test-api/images/homer-the-heretic-simpsons.jpg",
+		"synopsis": "After skipping church one week, Homer decides that he is never going back. However, when a calamity occurs, it takes the combined efforts of a number of people from different faiths to save him.",
+		"season": 4,
+		"episode": 3
+	},
+	"s5e2": {
+		"title": "Cape Feare",
+		"image": "http://3ev.org/dev-test-api/images/sideshow-bob-rake-simpsons.png",
+		"synopsis": "After being released from prison on parole, Sideshow Bob plots to murder Bart.",
+		"season": 5,
+		"episode": 2
+	},
+	"s5e13": {
+		"title": "Deep Space Homer",
+		"image": "http://3ev.org/dev-test-api/images/deep-space-homer-simpsons.jpg",
+		"synopsis": "In an effort to increase the dismal television ratings for their space launches, NASA decides to send an ordinary man into space, and Homer is chosen for the task.",
+		"season": 5,
+		"episode": 13
+	},
+	"s9e1": {
+		"title": "The City of New York Vs. Homer Simpson",
+		"image": "http://3ev.org/dev-test-api/images/The-city-of-new-york-vs-homer-simpsons.jpg",
+		"synopsis": "Homer must travel to New York to get his car back, which is illegally parked at World Trade Center Plaza.",
+		"season": 9,
+		"episode": 1
+	}
+}

--- a/public/index.php
+++ b/public/index.php
@@ -5,13 +5,25 @@ require_once '../vendor/autoload.php';
 $loader = new Twig_Loader_Filesystem('../templates/');
 $twig = new Twig_Environment($loader, ['debug' => true]);
 
-//Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
+$current_time = time();
+$expire_time = 24 * 60 * 60;
+$file_name = 'episodes-cache.txt';
+$file_time = file_exists($file_name) ? filemtime($file_name) : $current_time - $expire_time;
+if(file_exists($file_name) && ($current_time - $expire_time < $file_time)) {
+  $data = json_decode(file_get_contents($file_name), true);
+} else {
+  //Get the episodes from the API
+  $client = new GuzzleHttp\Client();
+  $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+  $data = json_decode($res->getBody(), true);
+  file_put_contents($file_name, $res->getBody());
+}
+
 
 //Sort the episodes
 array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);
+
+


### PR DESCRIPTION
Simple caching has been added by allowing the data from the API to be stored in a text file. If the text file exists and the file is within the last 24 hours, then it will be read and the data from the file will be used. Otherwise, the API will be called, and that used instead, with the data being written away to the cache for next time.

---

**Testing**

Check to make sure that the cache file is being created without errors and content is being added. You could prevent access to the API and allow it to just load from the cache to prove that is working. Or make changes to the API data so that the old cached data is loaded instead.

---

**Deployment steps**

This may have some conflicts with the issue 2 fix (PR #3) which checks for 500 errors on the API. The location of the cache file may need to be changed to somewhere more cache files could be store.

Merge branch `change1` into `master`
