### PR TITLE
Change 2 - Add in basic filter

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,5 +13,11 @@ $data = json_decode($res->getBody(), true);
 //Sort the episodes
 array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
 
+// get list of unique seasons for filter
+$seasons = array_unique(array_column($data, 'season'));
+
+//Get filter
+$filter = isset($_GET['filter']) ? $_GET['filter'] : '';
+
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', ["episodes" => $data, "seasons" => $seasons, "filter" => $filter]);

--- a/public/resources/sass/components/_episode.scss
+++ b/public/resources/sass/components/_episode.scss
@@ -2,6 +2,10 @@
     p {
         font-family: 'PT Serif', serif;
         font-size: 15px;
-        line-height: 25px;            
+        line-height: 25px;
     }
+}
+
+.no-episodes {
+  margin-bottom: 20px;
 }

--- a/templates/page.html
+++ b/templates/page.html
@@ -14,14 +14,30 @@
       </div>
     </div>
 
+    {% if seasons|length > 1 %}
+        <div class="container" id="filter" style="margin-bottom: 20px;">
+            <a href="/#filter" class="btn btn-primary">View all</a>
+            {% for season in seasons %}
+                <a href="/?filter={{ season }}#filter" class="btn {% if season == filter %}btn-success{% else %}btn-primary{% endif %}">Season {{ season }}</a>
+            {% endfor %}
+        </div>
+    {% endif %}
     <div class="container">
-        {% for episode in episodes %}
-            {% if loop.index%2 == 1 %}<div class="row">{%endif %}
 
-                {{ include('episode.html') }}
-        
-            {% if loop.index%2 == 0 %}</div>{%endif %}
+        {% set displayCount = 1 %}
+        {% for episode in episodes %}
+            {% if filter == episode.season or filter == '' %}
+                {% if displayCount%2 == 1 %}<div class="row">{% endif %}
+
+                    {{ include('episode.html') }}
+
+                {% if displayCount%2 == 0 %}</div>{% endif %}
+                {% set displayCount = (displayCount + 1) %}
+            {% endif %}
         {% endfor %}
+        {% if displayCount == 1 %}
+          <div class="no-episodes">There are no episodes for season {{ filter }}.</div>
+        {% endif %}
     </div>
 
     <footer class="footer">


### PR DESCRIPTION
This PR adds a very basic filter which could be improved upon massively with a little more time and some design. 

Firstly, we get all the unique season numbers provided by the API (PR#1 would sort these for us) and then use this to create a simple menu with a filter button for each available season. By default, we show all episodes. Clicking on a filter would redirect to the same page passing on the selected filter via the URL. We pull this number out of the URL and pass it to the template.

The current template loop through each episode is adjusted to check for a filter match, if a filter hasn't been selected then we just show the episode.

We keep a new count of how many episodes have been added so that we can alter the row calculation currently there, and also display a notification if no episodes were found.

A possible improvement would be to allow for multiple filters to be selected, or for Javascript to be used so that the filter could be done on page, without any page reloading. A better-looking filter method could also replace the basic button option currently on display.

---

**Testing**

Load the page and select from the options of seasons provided. Check that they filter appropriately.

---

**Deployment steps**

Tell us what we would need to do to get your changes into production. (We are aware that in this test, this is mostly a case of merging your branch). e.g.

Merge branch `change2` into `master`

Compile assets: `./node_modules/bin/gulp`
